### PR TITLE
feat/like-comment: implement feature like and unlike a comment

### DIFF
--- a/backend/prisma/migrations/20250807100341_add_comment_like/migration.sql
+++ b/backend/prisma/migrations/20250807100341_add_comment_like/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE `CommentLike` (
+    `userId` INTEGER NOT NULL,
+    `commentId` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`userId`, `commentId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `CommentLike` ADD CONSTRAINT `CommentLike_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `CommentLike` ADD CONSTRAINT `CommentLike_commentId_fkey` FOREIGN KEY (`commentId`) REFERENCES `PostComment`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250807101200_add_likes_count_to_postcomment/migration.sql
+++ b/backend/prisma/migrations/20250807101200_add_likes_count_to_postcomment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `PostComment` ADD COLUMN `likesCount` INTEGER NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -126,6 +126,7 @@ model User {
   postShares            PostShare[]
   postLikes             PostLike[]
   postComments          PostComment[]
+  commentLikes          CommentLike[]
   conversationMembers   Member[]
   sentMessages          Message[]         @relation("MessageSender")
   seenMessages          Seen[]
@@ -343,12 +344,14 @@ model PostComment {
   userId       Int
   comment      String
   repliesCount Int      @default(0)
+  likesCount   Int      @default(0)
   createdAt    DateTime @default(now())
 
   post          Post          @relation(fields: [postId], references: [id], onDelete: Cascade)
   user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   parentComment PostComment?  @relation("CommentReply", fields: [replyOf], references: [id], onDelete: Cascade)
   replies       PostComment[] @relation("CommentReply")
+  likes         CommentLike[]
 }
 
 model PostMedia {
@@ -358,6 +361,17 @@ model PostMedia {
   type   MediaType
 
   post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+}
+
+model CommentLike {
+  userId    Int
+  commentId Int
+  createdAt DateTime @default(now())
+
+  user    User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  comment PostComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  @@id([userId, commentId])
 }
 
 model Conversation {

--- a/backend/src/modules/comments/comments.controller.ts
+++ b/backend/src/modules/comments/comments.controller.ts
@@ -88,4 +88,26 @@ export class CommentsController {
   ) {
     return this.commentsService.getReplies(postId, commentId, filter);
   }
+
+  @Post(':commentId/like')
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(200)
+  async like(
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @CurrentUser('user') user: User,
+  ) {
+    return this.commentsService.likeComment(user.id, postId, commentId);
+  }
+
+  @Delete(':commentId/like')
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(200)
+  async unlike(
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @CurrentUser('user') user: User,
+  ) {
+    return this.commentsService.unlikeComment(user.id, postId, commentId);
+  }
 }


### PR DESCRIPTION
# Feature: Like / Unlike Comment

This feature allows users to like or unlike comments.

### Related Tickets

[[Redmine Ticket]](https://edu-redmine.sun-asterisk.vn/issues/90699)

--

### Endpoint 1

`POST /api/posts/:postId/comments/:commentId/like`

### Description

Like a comment. Update comment's likesCount after like.

| Parameter   | Description       | Example                 |
| ----------- | ----------------- | ----------------------- |
| `postId`    | ID of the post    | `/posts/1/comments/...` |
| `commentId` | ID of the comment | `/comments/1/like`      |

### Authentication

Required

### Response

HTTP 200

```json
{
  "message": "Comment liked"
}
```

---

### Endpoint 2

`DELETE /api/posts/:postId/comments/:commentId/like`

### Description

Unlike a previously liked comment. Update comment's likesCount after unlike.

| Parameter   | Description       | Example                 |
| ----------- | ----------------- | ----------------------- |
| `postId`    | ID of the post    | `/posts/1/comments/...` |
| `commentId` | ID of the comment | `/comments/1/like`      |

### Authentication

Required

### Response

HTTP 200
```json
{
  "message": "Comment unliked"
}
```

