### PR TITLE
refactor/post: replace MediaCarousel with MediaGrid, remove unused share functionality, and implement PostDetail page

### DIFF
--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -11,19 +11,14 @@ import {
   likePost,
   unlikePost,
   updatePost,
-  sharePost,
   savePost,
   unsavePost,
 } from "../../services/post.service";
-import { getConversations, createConversation } from "../../services/conversation.service";
-import Comments from "./Comments";
+
 import { useAuth } from "../../contexts/AuthContext";
 import UserHeader from "../common/user/UserHeader";
-import MediaCarousel from "../common/media/MediaCarousel";
-import { showErrorAlert, showSuccessAlert } from "../../utils/utils";
-import EmojiPicker from "emoji-picker-react";
-import { io, Socket } from "socket.io-client";
-import { getAccessToken } from "../../services/api.service";
+import MediaGrid from "../common/media/MediaGrid";
+import { showErrorAlert } from "../../utils/utils";
 
 interface PostProps {
   post: PostEntity;
@@ -31,13 +26,19 @@ interface PostProps {
   className?: string;
 }
 
-export default function Post({ post, showActions = true, className = "" }: PostProps) {
+export default function Post({
+  post,
+  showActions = true,
+  className = "",
+}: PostProps) {
   const { user } = useAuth();
   const navigate = useNavigate();
 
   if (!post || !post.id || !post.author) {
     return (
-      <article className={`relative w-full bg-yellow-50 rounded-xl shadow-sm border border-yellow-200 overflow-hidden ${className}`}>
+      <article
+        className={`relative w-full bg-yellow-50 rounded-xl shadow-sm border border-yellow-200 overflow-hidden ${className}`}
+      >
         <div className="px-4 py-6 text-center text-gray-500 bg-gray-50">
           <p className="text-sm">Dữ liệu bài viết không hợp lệ</p>
         </div>
@@ -50,18 +51,16 @@ export default function Post({ post, showActions = true, className = "" }: PostP
   const [showDeleteMessage, setShowDeleteMessage] = useState(false);
   const [liking, setLiking] = useState(false);
   const [liked, setLiked] = useState<boolean>(Boolean(post.liked_by_me));
-  const [sharing, setSharing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState<boolean>(Boolean(post.saved_by_me));
-  const [editingInModal, setEditingInModal] = useState(false);
   const [showEditPopup, setShowEditPopup] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [captionDraft, setCaptionDraft] = useState<string>(post.caption || "");
-  const [showComments, setShowComments] = useState(false);
-  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+
   const feedDropdown = useDropdown();
   const sharePopup = useDropdown();
-  const [followingAuthor, setFollowingAuthor] = useState<boolean>(Boolean(post.following_author));
+  const [followingAuthor, setFollowingAuthor] = useState<boolean>(
+    Boolean(post.following_author)
+  );
 
   useEffect(() => {
     setFollowingAuthor(Boolean(post.following_author));
@@ -108,125 +107,16 @@ export default function Post({ post, showActions = true, className = "" }: PostP
     sharePopup.toggle();
   };
 
-  const handleShareToUser = async (userId: number) => {
-    if (sharing) return;
-    setSharing(true);
-    try {
-      const response = await sharePost(data.id);
-      if (response.sharesCount !== undefined) {
-        setData({ ...data, shares_count: response.sharesCount });
-      }
-
-      let conversationId: number;
-      try {
-        const conversation = await createConversation({ members: [userId] });
-        conversationId = conversation.conversation.id;
-      } catch (error: any) {
-        if (error.message?.includes('already exists')) {
-          const conversationsResponse = await getConversations();
-          const conversations = Array.isArray(conversationsResponse) ? conversationsResponse : conversationsResponse.conversations || [];
-
-          const existingConversation = conversations.find((conv: any) =>
-            conv.members?.length === 2 &&
-            conv.members?.some((member: any) => member.id === userId)
-          );
-          if (!existingConversation) {
-            throw new Error('Không thể tìm conversation hiện có');
-          }
-          conversationId = existingConversation.id;
-        } else {
-          throw error;
-        }
-      }
-
-      const postUrl = `${window.location.origin}/posts/${data.id}`;
-      const messageContent = `Xem bài viết này: ${data.caption ? data.caption.substring(0, 100) + '...' : 'Bài viết mới'} ${postUrl}`;
-
-      const token = getAccessToken();
-      if (!token) {
-        throw new Error('Không có token xác thực');
-      }
-
-      const socket = io('http://localhost:3000/messages', {
-        auth: { token }
-      });
-
-      await new Promise((resolve, reject) => {
-        socket.on('connect', () => {
-          const payload = {
-            conversationId,
-            content: messageContent,
-            type: 'POST' as const,
-            replyOf: null as number | null,
-          };
-
-          socket.emit('send_message', payload, (response: any) => {
-            if (response && response.error) {
-              reject(new Error(response.error));
-            } else {
-              resolve(response);
-            }
-          });
-        });
-
-        socket.on('connect_error', (error) => {
-          reject(error);
-        });
-
-        setTimeout(() => {
-          reject(new Error('Kết nối timeout'));
-        }, 10000);
-      });
-
-      socket.disconnect();
-      sharePopup.close();
-      showSuccessAlert("Đã chia sẻ bài viết qua tin nhắn!");
-    } catch (e) {
-      showErrorAlert(e, "Không thể chia sẻ bài viết. Vui lòng thử lại!");
-    } finally {
-      setSharing(false);
-    }
-  };
-
-  const handleShareToSocial = async (platform: string) => {
-    if (sharing) return;
-    setSharing(true);
-    try {
-      const response = await sharePost(data.id);
-      if (response.sharesCount !== undefined) {
-        setData({ ...data, shares_count: response.sharesCount });
-      }
-      sharePopup.close();
-
-      const shareUrl = `${window.location.origin}/posts/${data.id}`;
-      const shareText = `Xem bài viết này: ${data.caption.substring(0, 100)}...`;
-
-      switch (platform) {
-        case 'facebook':
-          window.open(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`, '_blank');
-          break;
-        case 'twitter':
-          window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`, '_blank');
-          break;
-        case 'copy':
-          navigator.clipboard.writeText(shareUrl);
-          alert("Đã sao chép link bài viết!");
-          break;
-      }
-    } catch (e) {
-      showErrorAlert(e, "Không thể chia sẻ bài viết. Vui lòng thử lại!");
-    } finally {
-      setSharing(false);
-    }
-  };
-
   const handleToggleSave = async () => {
     if (saving) return;
     setSaving(true);
     try {
       if (saved) {
         await unsavePost(data.id);
-        setData({ ...data, saves_count: Math.max(0, (data.saves_count || 0) - 1) });
+        setData({
+          ...data,
+          saves_count: Math.max(0, (data.saves_count || 0) - 1),
+        });
         setSaved(false);
       } else {
         await savePost(data.id);
@@ -242,7 +132,9 @@ export default function Post({ post, showActions = true, className = "" }: PostP
 
   if (showDeleteMessage) {
     return (
-      <article className={`relative w-full bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}>
+      <article
+        className={`relative w-full bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}
+      >
         <div className="px-4 py-6 text-center text-green-600 bg-green-50">
           <TrashIcon className="w-8 h-8 mx-auto mb-2 text-green-500" />
           <p className="text-sm font-medium">Bài viết đã được xóa thành công</p>
@@ -257,37 +149,59 @@ export default function Post({ post, showActions = true, className = "" }: PostP
 
   const menuItems = [
     {
-      id: 'edit',
-      label: 'Chỉnh sửa',
+      id: "edit",
+      label: "Chỉnh sửa",
       icon: (
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+          />
         </svg>
       ),
       onClick: () => {
         setShowEditPopup(true);
         feedDropdown.close();
-      }
+      },
     },
     {
-      id: 'delete',
-      label: 'Xóa bài',
-      variant: 'danger' as const,
+      id: "delete",
+      label: "Xóa bài",
+      variant: "danger" as const,
       icon: (
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+          />
         </svg>
       ),
       onClick: () => {
         openDeleteConfirm();
         feedDropdown.close();
-      }
-    }
+      },
+    },
   ];
 
   return (
     <>
-      <article className={`relative w-full bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}>
+      <article
+        className={`relative w-full bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}
+      >
         <div className="flex items-center justify-between p-4">
           <UserHeader
             user={data.author}
@@ -310,7 +224,9 @@ export default function Post({ post, showActions = true, className = "" }: PostP
               <p className="text-gray-900 mb-2">
                 <span
                   className="text-yellow-500 font-medium hover:underline cursor-pointer"
-                  onClick={() => navigate(`/recipe/${data.recipe.slug || data.recipe.id}`)}
+                  onClick={() =>
+                    navigate(`/recipe/${data.recipe.slug || data.recipe.id}`)
+                  }
                 >
                   @{data.recipe.title}
                 </span>
@@ -322,7 +238,7 @@ export default function Post({ post, showActions = true, className = "" }: PostP
 
         {data.media && data.media.length > 0 && (
           <div className="w-full">
-            <MediaCarousel items={data.media} />
+            <MediaGrid items={data.media} postId={data.id} />
           </div>
         )}
 
@@ -337,7 +253,7 @@ export default function Post({ post, showActions = true, className = "" }: PostP
               isLiked={liked}
               isSaved={saved}
               onLikeToggle={handleToggleLike}
-              onCommentClick={() => setShowComments(true)}
+              onCommentClick={() => navigate(`/post/${data.id}`)}
               onShareClick={handleShareClick}
               onSaveClick={handleToggleSave}
             />
@@ -345,179 +261,16 @@ export default function Post({ post, showActions = true, className = "" }: PostP
         )}
       </article>
 
-      {showComments && (
-        <div className="fixed inset-0 bg-yellow-50 bg-opacity-95 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex">
-            <div className="flex-1 bg-black overflow-hidden relative flex items-center justify-center">
-              {data.media && data.media.length > 0 && (
-                <div className="w-full h-full flex items-center justify-center">
-                  <MediaCarousel items={data.media} />
-                </div>
-              )}
-
-              <button
-                onClick={() => setShowComments(false)}
-                className="absolute top-4 left-4 bg-black bg-opacity-50 text-white hover:text-gray-300 transition-colors z-10 rounded-full p-2"
-              >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            <div className="w-96 bg-white flex flex-col max-h-[90vh] overflow-hidden">
-              <div className="p-4 border-b border-gray-200 flex items-center justify-between">
-                <UserHeader
-                  user={data.author}
-                  timestamp={data.created_at}
-                  size="md"
-                  showFollowButton={true}
-                  isFollowing={followingAuthor}
-                  currentUserId={user?.id}
-                  onFollowChange={(isFollowing) => setFollowingAuthor(isFollowing)}
-                />
-
-                {user && user.id === data.author.id && (
-                  <ThreeDotsMenu
-                    items={[
-                      {
-                        id: 'edit',
-                        label: 'Chỉnh sửa',
-                        icon: (
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                          </svg>
-                        ),
-                        onClick: () => {
-                          setEditingInModal(true);
-                          setCaptionDraft(data.caption || "");
-                        }
-                      },
-                      {
-                        id: 'delete',
-                        label: 'Xóa bài',
-                        variant: 'danger',
-                        icon: (
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        ),
-                        onClick: () => {
-                          openDeleteConfirm();
-                        }
-                      }
-                    ]}
-                  />
-                )}
-              </div>
-
-              {(data.recipe || data.caption) && (
-                <div className="p-4 border-b border-gray-200">
-                  {data.recipe && (
-                    <p className="text-gray-900 mb-2">
-                      <span
-                        className="text-yellow-500 font-medium hover:underline cursor-pointer"
-                        onClick={() => navigate(`/recipe/${data.recipe.slug || data.recipe.id}`)}
-                      >
-                        @{data.recipe.title}
-                      </span>
-                    </p>
-                  )}
-                  {editingInModal ? (
-                    <div className="relative">
-                      <textarea
-                        value={captionDraft}
-                        onChange={(e) => setCaptionDraft(e.target.value)}
-                        className="w-full p-3 border border-gray-300 rounded-lg resize-none text-sm"
-                        rows={3}
-                        placeholder="Nhập nội dung bài viết..."
-                        autoFocus
-                      />
-                      <div className="flex items-center justify-between mt-2">
-                        <button
-                          onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-                          className="text-gray-500 hover:text-gray-700 p-1"
-                        >
-                          😊
-                        </button>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => {
-                              setEditingInModal(false);
-                              setCaptionDraft(data.caption || "");
-                            }}
-                            className="px-3 py-1 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50"
-                          >
-                            Hủy
-                          </button>
-                          <button
-                            onClick={async () => {
-                              try {
-                                await updatePost(data.id, {
-                                  caption: captionDraft
-                                });
-                                setData({ ...data, caption: captionDraft });
-                                setEditingInModal(false);
-                              } catch (e) {
-                                showErrorAlert(e, "Không thể cập nhật bài viết. Vui lòng thử lại!");
-                              }
-                            }}
-                            className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
-                          >
-                            Lưu
-                          </button>
-                        </div>
-                      </div>
-                      {showEmojiPicker && (
-                        <div className="absolute top-full left-0 mt-2 z-10">
-                          <EmojiPicker
-                            onEmojiClick={(emojiObject) => {
-                              setCaptionDraft(prev => prev + emojiObject.emoji);
-                              setShowEmojiPicker(false);
-                            }}
-                            width={300}
-                            height={400}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <p className="text-gray-900">{data.caption}</p>
-                  )}
-                </div>
-              )}
-
-              <div className="p-4 border-b border-gray-200">
-                <PostActionBar
-                  variant="detail"
-                  likesCount={data.likes_count}
-                  commentsCount={data.comments_count}
-                  sharesCount={data.shares_count || 0}
-                  savesCount={data.saves_count || 0}
-                  isLiked={liked}
-                  isSaved={saved}
-                  onLikeToggle={handleToggleLike}
-                  onCommentClick={() => { }}
-                  onShareClick={handleShareClick}
-                  onSaveClick={handleToggleSave}
-                />
-              </div>
-
-              <div className="flex-1 min-h-0 overflow-y-auto">
-                <Comments postId={data.id} />
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
       <SharePopup
         isOpen={sharePopup.isOpen}
         onClose={sharePopup.close}
-        onShareToUser={handleShareToUser}
-        onShareToSocial={handleShareToSocial}
         postCaption={data.caption}
         postId={data.id}
+        onShareSuccess={(sharesCount) => {
+          setData((prev) =>
+            prev ? { ...prev, shares_count: sharesCount } : prev
+          );
+        }}
       />
 
       <EditPostPopup

--- a/frontend/src/components/common/media/MediaCarousel.tsx
+++ b/frontend/src/components/common/media/MediaCarousel.tsx
@@ -26,8 +26,6 @@ export default function MediaCarousel({ items, className = "" }: MediaCarouselPr
   };
 
   const currentItem = items[index];
-  const nextItem = items[(index + 1) % total];
-  const showDouble = total >= 2 && currentItem.type === "IMAGE" && nextItem.type === "IMAGE";
 
   if (!currentItem) return null;
 
@@ -37,39 +35,22 @@ export default function MediaCarousel({ items, className = "" }: MediaCarouselPr
         <>
           <button
             aria-label="Previous"
-            className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-8 h-8 z-10 flex items-center justify-center transition-colors"
+            className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-10 h-10 z-10 flex items-center justify-center transition-colors"
             onClick={() => go(-1)}
           >
-            <ChevronLeftIcon className="w-4 h-4" />
+            <ChevronLeftIcon className="w-5 h-5" />
           </button>
           <button
             aria-label="Next"
-            className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-8 h-8 z-10 flex items-center justify-center transition-colors"
+            className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-10 h-10 z-10 flex items-center justify-center transition-colors"
             onClick={() => go(1)}
           >
-            <ChevronRightIcon className="w-4 h-4" />
+            <ChevronRightIcon className="w-5 h-5" />
           </button>
         </>
       )}
 
-      {showDouble ? (
-        <div className="grid grid-cols-2 gap-1 w-full h-full">
-          <div className="w-full h-full flex items-center justify-center">
-            <img
-              className="w-full h-full object-contain"
-              src={currentItem.url}
-              alt="media 1"
-            />
-          </div>
-          <div className="w-full h-full flex items-center justify-center">
-            <img
-              className="w-full h-full object-contain"
-              src={nextItem.url}
-              alt="media 2"
-            />
-          </div>
-        </div>
-      ) : currentItem.type === "VIDEO" ? (
+      {currentItem.type === "VIDEO" ? (
         <div className="w-full h-full relative flex items-center justify-center">
           <video
             className="w-full h-full object-contain"

--- a/frontend/src/components/common/media/MediaGrid.tsx
+++ b/frontend/src/components/common/media/MediaGrid.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+interface MediaItem {
+  id?: number;
+  url: string;
+  type: "IMAGE" | "VIDEO";
+}
+
+interface MediaGridProps {
+  items: MediaItem[];
+  postId: number;
+  className?: string;
+}
+
+export default function MediaGrid({
+  items,
+  postId,
+  className = "",
+}: MediaGridProps) {
+  const navigate = useNavigate();
+
+  if (!items || items.length === 0) return null;
+
+  const handleClick = () => {
+    navigate(`/post/${postId}`);
+  };
+
+  const displayItems = items.slice(0, 5);
+  const remainingCount = items.length - 5;
+
+  const getGridLayout = () => {
+    switch (displayItems.length) {
+      case 1:
+        return "grid-cols-1";
+      case 2:
+        return "grid-cols-2";
+      case 3:
+        return "grid-cols-2";
+      case 4:
+        return "grid-cols-2";
+      case 5:
+        return "grid-cols-3";
+      default:
+        return "grid-cols-1";
+    }
+  };
+
+  const getItemLayout = (index: number) => {
+    if (displayItems.length === 3) {
+      return index === 0 ? "row-span-2" : "";
+    }
+    if (displayItems.length === 5) {
+      return index === 0 ? "row-span-2" : "";
+    }
+    return "";
+  };
+
+  const getGridHeight = () => {
+    switch (displayItems.length) {
+      case 1:
+        return "h-96";
+      case 2:
+        return "h-80";
+      case 3:
+        return "h-80";
+      case 4:
+        return "h-80";
+      case 5:
+        return "h-80";
+      default:
+        return "h-96";
+    }
+  };
+
+  return (
+    <div className={`w-full cursor-pointer ${className}`} onClick={handleClick}>
+      <div className={`grid ${getGridLayout()} gap-1 ${getGridHeight()}`}>
+        {displayItems.map((item, index) => (
+          <div
+            key={index}
+            className={`relative overflow-hidden ${getItemLayout(index)} ${
+              index === 4 && remainingCount > 0
+                ? "brightness-75 contrast-125"
+                : ""
+            }`}
+          >
+            {item.type === "VIDEO" ? (
+              <div className="w-full h-full relative">
+                <video
+                  className="w-full h-full object-cover"
+                  src={item.url}
+                  preload="metadata"
+                />
+                <div className="absolute bottom-2 right-2 bg-black bg-opacity-70 text-white text-xs px-2 py-1 rounded flex items-center gap-1">
+                  <svg
+                    className="w-3 h-3"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                  <span>Video</span>
+                </div>
+              </div>
+            ) : (
+              <img
+                className="w-full h-full object-cover"
+                src={item.url}
+                alt={`media ${index + 1}`}
+              />
+            )}
+
+            {index === 4 && remainingCount > 0 && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="absolute inset-0 bg-black/25"></div>
+                <span className="relative text-white text-2xl font-bold drop-shadow-lg z-10">
+                  +{remainingCount}
+                </span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/popup/EditPostPopup.tsx
+++ b/frontend/src/components/popup/EditPostPopup.tsx
@@ -8,7 +8,7 @@ import { updatePost } from "../../services/post.service";
 import { showErrorAlert } from "../../utils/errorHandler";
 import RecipeSelectionModal from "./RecipeSelectionModal";
 import type { RecipeListItem } from "../../services/recipe.service";
-import { getAccessToken } from "../../services/api.service";
+import { uploadFiles } from "../../services/upload.service";
 
 interface EditPostPopupProps {
   post: PostEntity;
@@ -115,33 +115,9 @@ export default function EditPostPopup({
   };
 
   const uploadMediaToCloudinary = async (files: File[]) => {
-    const formData = new FormData();
-    files.forEach((file) => {
-      formData.append('files', file);
-    });
-
-    const token = getAccessToken();
-    
-    if (!token) {
-      throw new Error('No access token found. Please login again.');
-    }
-
     try {
-      const response = await fetch('http://localhost:3000/api/cloudinary/upload', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Upload failed: ${response.status} ${errorText}`);
-      }
-
-      const data = await response.json();
-      return data;
+      const uploadedMedia = await uploadFiles(files);
+      return uploadedMedia;
     } catch (error) {
       throw error;
     }
@@ -167,9 +143,9 @@ export default function EditPostPopup({
         
         const uploadedMediaItems: PostMedia[] = uploadedMedia.map((item: any, index: number) => ({
           id: Date.now() + index,
-          url: item.url || item.secure_url,
-          type: (item.resourceType || item.resource_type || 'image').toUpperCase() as 'IMAGE' | 'VIDEO',
-          public_id: item.publicId || item.public_id,
+          url: item.url,
+          type: (item.resourceType || 'image').toUpperCase() as 'IMAGE' | 'VIDEO',
+          public_id: item.publicId,
         }));
 
         finalMedia = [...finalMedia, ...uploadedMediaItems];

--- a/frontend/src/components/popup/SharePopup.tsx
+++ b/frontend/src/components/popup/SharePopup.tsx
@@ -1,215 +1,368 @@
 import { useState, useEffect, useCallback } from "react";
 import { searchUsers } from "../../services/user.service";
-import { showErrorAlert } from "../../utils/utils";
+import { showErrorAlert, showSuccessAlert } from "../../utils/utils";
+import { sharePost } from "../../services/post.service";
+import { getConversations, createConversation } from "../../services/conversation.service";
+import { io } from "socket.io-client";
+import { getAccessToken } from "../../services/api.service";
 
 interface SharePopupProps {
-    isOpen: boolean;
-    onClose: () => void;
-    onShareToUser: (userId: number) => void;
-    onShareToSocial: (platform: string) => void;
-    postCaption?: string;
-    postId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  postCaption?: string;
+  postId: number;
+  onShareSuccess?: (sharesCount: number) => void;
 }
 
 export default function SharePopup({
-    isOpen,
-    onClose,
-    onShareToUser,
-    onShareToSocial,
-    postCaption = "",
-    postId,
+  isOpen,
+  onClose,
+  postCaption = "",
+  postId,
+  onShareSuccess,
 }: SharePopupProps) {
-    const [activeTab, setActiveTab] = useState<'social' | 'messages'>('social');
-    const [searchQuery, setSearchQuery] = useState('');
-    const [searchResults, setSearchResults] = useState<any[]>([]);
-    const [isSearching, setIsSearching] = useState(false);
+  const [activeTab, setActiveTab] = useState<"social" | "messages">("social");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [sharing, setSharing] = useState(false);
 
-    const debouncedSearch = useCallback(
-        (() => {
-            let timeoutId: number;
-            return (query: string) => {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(async () => {
-                    if (query.trim().length < 2) {
-                        setSearchResults([]);
-                        return;
-                    }
+  const debouncedSearch = useCallback(
+    (() => {
+      let timeoutId: number;
+      return (query: string) => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(async () => {
+          if (query.trim().length < 2) {
+            setSearchResults([]);
+            return;
+          }
 
-                    setIsSearching(true);
-                    try {
-                        const users = await searchUsers(query);
-                        setSearchResults(users);
-                    } catch (error) {
-                        showErrorAlert(error, "Không thể tìm kiếm người dùng. Vui lòng thử lại!");
-                        setSearchResults([]);
-                    } finally {
-                        setIsSearching(false);
-                    }
-                }, 300);
-            };
-        })(),
-        []
-    );
+          setIsSearching(true);
+          try {
+            const users = await searchUsers(query);
+            setSearchResults(users);
+          } catch (error) {
+            showErrorAlert(
+              error,
+              "Không thể tìm kiếm người dùng. Vui lòng thử lại!"
+            );
+            setSearchResults([]);
+          } finally {
+            setIsSearching(false);
+          }
+        }, 300);
+      };
+    })(),
+    []
+  );
 
-    const handleSearchUsers = (query: string) => {
-        setSearchQuery(query);
-        debouncedSearch(query);
-    };
+  const handleSearchUsers = (query: string) => {
+    setSearchQuery(query);
+    debouncedSearch(query);
+  };
 
-    const handleShareToSocial = (platform: string) => {
-        onShareToSocial(platform);
-    };
+  const handleShareToSocial = async (platform: string) => {
+    if (sharing) return;
+    setSharing(true);
+    try {
+      const response = await sharePost(postId);
+      if (response.sharesCount !== undefined) {
+        onShareSuccess?.(response.sharesCount);
+      }
+      onClose();
 
-    const handleShareToUser = (userId: number) => {
-        onShareToUser(userId);
-    };
+      const shareUrl = `${window.location.origin}/post/${postId}`;
+      const shareText = `Xem bài viết này: ${postCaption ? postCaption.substring(0, 100) + '...' : 'Bài viết mới'}`;
 
-    if (!isOpen) return null;
+      switch (platform) {
+        case 'facebook':
+          window.open(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`, '_blank');
+          break;
+        case 'twitter':
+          window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`, '_blank');
+          break;
+        case 'copy':
+          navigator.clipboard.writeText(shareUrl);
+          showSuccessAlert("Đã sao chép link bài viết!");
+          break;
+      }
+    } catch (e) {
+      showErrorAlert(e, "Không thể chia sẻ bài viết. Vui lòng thử lại!");
+    } finally {
+      setSharing(false);
+    }
+  };
 
-    return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-            <div
-                className="fixed inset-0"
-                onClick={onClose}
-            ></div>
-            <div
-                className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md relative border border-yellow-600/10"
-                style={{
-                    animation: 'popup 0.4s cubic-bezier(0.16, 1, 0.3, 1)'
-                }}
-            >
-                <button
-                    className="absolute top-4 right-4 p-2 text-gray-400 hover:text-yellow-600 hover:scale-110 transition-all duration-300"
-                    onClick={onClose}
-                >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
+  const handleShareToUser = async (userId: number) => {
+    if (sharing) return;
+    setSharing(true);
+    try {
+      const response = await sharePost(postId);
+      if (response.sharesCount !== undefined) {
+        onShareSuccess?.(response.sharesCount);
+      }
 
-                <h3 className="text-2xl font-bold mb-6 text-gray-800">
-                    Chia sẻ bài viết
-                </h3>
+      let conversationId: number;
+      try {
+        const conversation = await createConversation({ members: [userId] });
+        conversationId = conversation.conversation.id;
+      } catch (error: any) {
+        if (error.message?.includes('already exists')) {
+          const conversationsResponse = await getConversations();
+          const conversations = Array.isArray(conversationsResponse) ? conversationsResponse : conversationsResponse.conversations || [];
 
-                <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
-                    <button
-                        onClick={() => setActiveTab('social')}
-                        className={`flex-1 py-2 px-4 rounded-lg font-medium transition-all ${activeTab === 'social'
-                            ? 'bg-white text-yellow-600 shadow-sm'
-                            : 'text-gray-600 hover:text-gray-800'
-                            }`}
-                    >
-                        Mạng xã hội
-                    </button>
-                    <button
-                        onClick={() => setActiveTab('messages')}
-                        className={`flex-1 py-2 px-4 rounded-lg font-medium transition-all ${activeTab === 'messages'
-                            ? 'bg-white text-yellow-600 shadow-sm'
-                            : 'text-gray-600 hover:text-gray-800'
-                            }`}
-                    >
-                        Tin nhắn
-                    </button>
-                </div>
+          const existingConversation = conversations.find((conv: any) =>
+            conv.members?.length === 2 &&
+            conv.members?.some((member: any) => member.id === userId)
+          );
+          if (!existingConversation) {
+            throw new Error('Không thể tìm conversation hiện có');
+          }
+          conversationId = existingConversation.id;
+        } else {
+          throw error;
+        }
+      }
 
-                {activeTab === 'social' ? (
-                    <div className="flex flex-col gap-4">
-                        <button
-                            onClick={() => handleShareToSocial('copy')}
-                            className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
-                        >
-                            <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                </svg>
-                            </div>
-                            <span>Copy link</span>
-                        </button>
+      const postUrl = `${window.location.origin}/post/${postId}`;
+      const messageContent = `Xem bài viết này: ${postCaption ? postCaption.substring(0, 100) + '...' : 'Bài viết mới'} ${postUrl}`;
 
-                        <button
-                            onClick={() => handleShareToSocial('facebook')}
-                            className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
-                        >
-                            <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
-                                <svg className="w-5 h-5 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
-                                    <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-                                </svg>
-                            </div>
-                            <span>Chia sẻ Facebook</span>
-                        </button>
+      const token = getAccessToken();
+      if (!token) {
+        throw new Error('Không có token xác thực');
+      }
 
-                        <button
-                            onClick={() => handleShareToSocial('twitter')}
-                            className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
-                        >
-                            <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
-                                <svg className="w-5 h-5 text-sky-500" fill="currentColor" viewBox="0 0 24 24">
-                                    <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
-                                </svg>
-                            </div>
-                            <span>Chia sẻ Twitter</span>
-                        </button>
-                    </div>
-                ) : (
-                    <div>
-                        <div className="relative mb-4">
-                            <svg className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                            </svg>
-                            <input
-                                type="text"
-                                placeholder="Tìm kiếm cuộc trò chuyện..."
-                                value={searchQuery}
-                                onChange={(e) => handleSearchUsers(e.target.value)}
-                                className="w-full pl-10 pr-4 py-2 bg-gray-100 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-yellow-600 focus:bg-white transition-all"
-                            />
-                        </div>
+      const socket = io('http://localhost:3000/messages', {
+        auth: { token }
+      });
 
-                        <div className="max-h-60 overflow-y-auto">
-                            {isSearching ? (
-                                <div className="text-center py-8 text-gray-500">
-                                    Đang tìm kiếm...
-                                </div>
-                            ) : (searchResults && searchResults.length > 0) ? (
-                                searchResults.map((user) => (
-                                    <button
-                                        key={user.id}
-                                        onClick={() => handleShareToUser(user.id)}
-                                        className="w-full flex items-center gap-3 p-3 rounded-xl hover:bg-yellow-50 transition-all duration-300 group"
-                                    >
-                                        <img
-                                            src={user.avatar || "/src/assets/avatar-default.svg"}
-                                            alt=""
-                                            className="w-12 h-12 rounded-full object-cover border-2 border-transparent group-hover:border-yellow-600 transition-all"
-                                        />
-                                        <div className="flex-1 text-left">
-                                            <div className="font-medium text-gray-800">
-                                                {user.firstName} {user.lastName}
-                                            </div>
-                                            <div className="text-sm text-gray-500">
-                                                @{user.username}
-                                            </div>
-                                        </div>
-                                        <svg className="w-5 h-5 text-gray-400 group-hover:text-yellow-600 transition-colors" fill="currentColor" viewBox="0 0 20 20">
-                                            <path fillRule="evenodd" d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clipRule="evenodd" />
-                                        </svg>
-                                    </button>
-                                ))
-                            ) : (searchQuery && searchQuery.length >= 2) ? (
-                                <div className="text-center py-8 text-gray-500">
-                                    Không tìm thấy người dùng
-                                </div>
-                            ) : (
-                                <div className="text-center py-8 text-gray-500">
-                                    Nhập tên người dùng để tìm kiếm
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                )}
+      await new Promise((resolve, reject) => {
+        socket.on('connect', () => {
+          const payload = {
+            conversationId,
+            content: messageContent,
+            type: 'POST' as const,
+            replyOf: null as number | null,
+          };
 
+          socket.emit('send_message', payload, (response: any) => {
+            if (response && response.error) {
+              reject(new Error(response.error));
+            } else {
+              resolve(response);
+            }
+          });
+        });
 
-            </div>
+        socket.on('connect_error', (error) => {
+          reject(error);
+        });
+
+        setTimeout(() => {
+          reject(new Error('Kết nối timeout'));
+        }, 10000);
+      });
+
+      socket.disconnect();
+      onClose();
+      showSuccessAlert("Đã chia sẻ bài viết qua tin nhắn!");
+    } catch (e) {
+      showErrorAlert(e, "Không thể chia sẻ bài viết. Vui lòng thử lại!");
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="fixed inset-0" onClick={onClose}></div>
+      <div
+        className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md relative border border-yellow-600/10"
+        style={{
+          animation: "popup 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
+        }}
+      >
+        <button
+          className="absolute top-4 right-4 p-2 text-gray-400 hover:text-yellow-600 hover:scale-110 transition-all duration-300"
+          onClick={onClose}
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+
+        <h3 className="text-2xl font-bold mb-6 text-gray-800">
+          Chia sẻ bài viết
+        </h3>
+
+        <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+          <button
+            onClick={() => setActiveTab("social")}
+            className={`flex-1 py-2 px-4 rounded-lg font-medium transition-all ${
+              activeTab === "social"
+                ? "bg-white text-yellow-600 shadow-sm"
+                : "text-gray-600 hover:text-gray-800"
+            }`}
+          >
+            Mạng xã hội
+          </button>
+          <button
+            onClick={() => setActiveTab("messages")}
+            className={`flex-1 py-2 px-4 rounded-lg font-medium transition-all ${
+              activeTab === "messages"
+                ? "bg-white text-yellow-600 shadow-sm"
+                : "text-gray-600 hover:text-gray-800"
+            }`}
+          >
+            Tin nhắn
+          </button>
         </div>
-    );
+
+        {activeTab === "social" ? (
+          <div className="flex flex-col gap-4">
+            <button
+              onClick={() => handleShareToSocial("copy")}
+              className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
+            >
+              <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <span>Copy link</span>
+            </button>
+
+            <button
+              onClick={() => handleShareToSocial("facebook")}
+              className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
+            >
+              <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
+                <svg
+                  className="w-5 h-5 text-blue-600"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+                </svg>
+              </div>
+              <span>Chia sẻ Facebook</span>
+            </button>
+
+            <button
+              onClick={() => handleShareToSocial("twitter")}
+              className="flex items-center gap-3 px-5 py-3 rounded-xl hover:bg-yellow-50 text-gray-700 font-medium transition-all duration-300 group"
+            >
+              <div className="p-2 rounded-full bg-gray-100 group-hover:bg-white group-hover:scale-110 transition-all duration-300">
+                <svg
+                  className="w-5 h-5 text-sky-500"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
+                </svg>
+              </div>
+              <span>Chia sẻ Twitter</span>
+            </button>
+          </div>
+        ) : (
+          <div>
+            <div className="relative mb-4">
+              <svg
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <input
+                type="text"
+                placeholder="Tìm kiếm cuộc trò chuyện..."
+                value={searchQuery}
+                onChange={(e) => handleSearchUsers(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-gray-100 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-yellow-600 focus:bg-white transition-all"
+              />
+            </div>
+
+            <div className="max-h-60 overflow-y-auto">
+              {isSearching ? (
+                <div className="text-center py-8 text-gray-500">
+                  Đang tìm kiếm...
+                </div>
+              ) : searchResults && searchResults.length > 0 ? (
+                searchResults.map((user) => (
+                  <button
+                    key={user.id}
+                    onClick={() => handleShareToUser(user.id)}
+                    className="w-full flex items-center gap-3 p-3 rounded-xl hover:bg-yellow-50 transition-all duration-300 group"
+                  >
+                    <img
+                      src={user.avatar || "/src/assets/avatar-default.svg"}
+                      alt=""
+                      className="w-12 h-12 rounded-full object-cover border-2 border-transparent group-hover:border-yellow-600 transition-all"
+                    />
+                    <div className="flex-1 text-left">
+                      <div className="font-medium text-gray-800">
+                        {user.firstName} {user.lastName}
+                      </div>
+                      <div className="text-sm text-gray-500">
+                        @{user.username}
+                      </div>
+                    </div>
+                    <svg
+                      className="w-5 h-5 text-gray-400 group-hover:text-yellow-600 transition-colors"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                ))
+              ) : searchQuery && searchQuery.length >= 2 ? (
+                <div className="text-center py-8 text-gray-500">
+                  Không tìm thấy người dùng
+                </div>
+              ) : (
+                <div className="text-center py-8 text-gray-500">
+                  Nhập tên người dùng để tìm kiếm
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/pages/main/PostDetail/PostDetail.tsx
+++ b/frontend/src/pages/main/PostDetail/PostDetail.tsx
@@ -1,0 +1,240 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getPostById } from "../../../services/post.service";
+import {
+  likePost,
+  unlikePost,
+  savePost,
+  unsavePost,
+} from "../../../services/post.service";
+import { showErrorAlert, showSuccessAlert } from "../../../utils/utils";
+import { useAuth } from "../../../contexts/AuthContext";
+import UserHeader from "../../../components/common/user/UserHeader";
+import MediaCarousel from "../../../components/common/media/MediaCarousel";
+import Comments from "../../../components/Post/Comments";
+import PostActionBar from "../../../components/common/ui/PostActionBar";
+import { SharePopup } from "../../../components/popup";
+import type { PostEntity } from "../../../types/post.type";
+
+export default function PostDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [post, setPost] = useState<PostEntity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [liking, setLiking] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [showSharePopup, setShowSharePopup] = useState(false);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (!id) return;
+
+      try {
+        setLoading(true);
+        const response = await getPostById(parseInt(id));
+        setPost(response.post);
+      } catch (err) {
+        setError("Không thể tải bài viết");
+        showErrorAlert(err, "Lỗi khi tải bài viết");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPost();
+  }, [id]);
+
+  const handleLike = async () => {
+    if (!post || !user) return;
+
+    try {
+      setLiking(true);
+      if (post.liked_by_me) {
+        await unlikePost(post.id);
+        setPost((prev) =>
+          prev
+            ? { ...prev, liked_by_me: false, likes_count: prev.likes_count - 1 }
+            : null
+        );
+      } else {
+        await likePost(post.id);
+        setPost((prev) =>
+          prev
+            ? { ...prev, liked_by_me: true, likes_count: prev.likes_count + 1 }
+            : null
+        );
+      }
+    } catch (err) {
+      showErrorAlert(err, "Không thể thực hiện thao tác");
+    } finally {
+      setLiking(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!post || !user) return;
+
+    try {
+      setSaving(true);
+      if (post.saved_by_me) {
+        await unsavePost(post.id);
+        setPost((prev) =>
+          prev
+            ? {
+                ...prev,
+                saved_by_me: false,
+                saves_count: (prev.saves_count || 0) - 1,
+              }
+            : null
+        );
+      } else {
+        await savePost(post.id);
+        setPost((prev) =>
+          prev
+            ? {
+                ...prev,
+                saved_by_me: true,
+                saves_count: (prev.saves_count || 0) + 1,
+              }
+            : null
+        );
+      }
+    } catch (err) {
+      showErrorAlert(err, "Không thể thực hiện thao tác");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#F5F1E8] flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Đang tải bài viết...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <div className="min-h-screen bg-[#F5F1E8] flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">
+            {error || "Bài viết không tồn tại"}
+          </p>
+          <button
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700"
+          >
+            Quay lại
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-yellow-50 bg-opacity-95 backdrop-blur-sm py-6">
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="bg-white rounded-xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex">
+          <div className="flex-1 bg-black overflow-hidden relative flex items-center justify-center">
+            {post.media && post.media.length > 0 && (
+              <div className="w-full h-full flex items-center justify-center">
+                <MediaCarousel items={post.media} />
+              </div>
+            )}
+
+            <button
+              onClick={() => navigate(-1)}
+              className="absolute top-4 left-4 bg-black bg-opacity-50 text-white hover:text-gray-300 transition-colors z-10 rounded-full p-2"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <div className="w-96 bg-white flex flex-col max-h-[90vh] overflow-hidden">
+            <div className="p-4 border-b border-gray-200 flex items-center justify-between">
+              <UserHeader
+                user={post.author}
+                timestamp={post.created_at}
+                size="md"
+                showFollowButton={true}
+                isFollowing={post.following_author}
+                currentUserId={user?.id}
+              />
+            </div>
+
+            {(post.recipe || post.caption) && (
+              <div className="p-4 border-b border-gray-200">
+                {post.recipe && (
+                  <p className="text-gray-900 mb-2">
+                    <span
+                      className="text-yellow-500 font-medium hover:underline cursor-pointer"
+                      onClick={() =>
+                        navigate(
+                          `/recipe/${post.recipe.slug || post.recipe.id}`
+                        )
+                      }
+                    >
+                      @{post.recipe.title}
+                    </span>
+                  </p>
+                )}
+                <p className="text-gray-900">{post.caption}</p>
+              </div>
+            )}
+
+            <div className="p-4 border-b border-gray-200">
+              <PostActionBar
+                variant="detail"
+                likesCount={post.likes_count}
+                commentsCount={post.comments_count}
+                sharesCount={post.shares_count || 0}
+                savesCount={post.saves_count || 0}
+                isLiked={Boolean(post.liked_by_me)}
+                isSaved={Boolean(post.saved_by_me)}
+                onLikeToggle={handleLike}
+                onCommentClick={() => {}}
+                onShareClick={() => setShowSharePopup(true)}
+                onSaveClick={handleSave}
+              />
+            </div>
+
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <Comments postId={post.id} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <SharePopup
+        isOpen={showSharePopup}
+        onClose={() => setShowSharePopup(false)}
+        postCaption={post.caption}
+        postId={post.id}
+        onShareSuccess={(sharesCount) => {
+          setPost((prev) =>
+            prev ? { ...prev, shares_count: sharesCount } : prev
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -18,6 +18,7 @@ import Blog2 from "../pages/blog/Blog2";
 import Blog3 from "../pages/blog/Blog3";
 import Blog4 from "../pages/blog/Blog4";
 import ProfilePage from "../pages/main/Profile/ProfilePage";
+import PostDetail from "../pages/main/PostDetail/PostDetail";
 
 export default function AppRouter() {
   return (
@@ -41,6 +42,14 @@ export default function AppRouter() {
         element={
           <MainLayout header={<Header />} footer={<Footer />}>
             <ProfilePage />
+          </MainLayout>
+        }
+      />
+      <Route
+        path="/post/:id"
+        element={
+          <MainLayout header={<Header />} footer={<Footer />}>
+            <PostDetail />
           </MainLayout>
         }
       />

--- a/frontend/src/services/post.service.ts
+++ b/frontend/src/services/post.service.ts
@@ -25,7 +25,7 @@ export async function fetchPosts(params?: FilterPostsDto) {
   return res.data;
 }
 
-export async function fetchPost(postId: number) {
+export async function getPostById(postId: number) {
   const res = await get<PostResponse>(`/posts/${postId}`);
   return res.data;
 }


### PR DESCRIPTION
# Related Tickets

[Ticket redmine link](https://edu-redmine.sun-asterisk.vn/issues/91778)

# Feature: Convert Post Modal to Dedicated PostDetail Page, Centralize Share Logic, and Apply Upload Service

### Description

This PR replaces the old post modal with a dedicated PostDetail route and page, ensures all entry points navigate to /post/:id, centralizes sharing logic into SharePopup, and switches Edit Post uploads to the shared upload service.

### New Features

1. PostDetail migration

- Replaced post modal with a dedicated page PostDetail at /post/:id.
- Updated feed “Comment” action to navigate to /post/:id instead of opening a modal.
- Replicated the old modal layout in PostDetail (media left, content/comments right).
- MediaCarousel now shows one image per slide (no side-by-side).

2. Share

- Moved full share logic (DM + social) into SharePopup.
- Post and PostDetail consume SharePopup; updated shares_count via onShareSuccess.

### UI Preview: 
<img width="1659" height="707" alt="image" src="https://github.com/user-attachments/assets/df47b159-d394-4c6f-a0e8-c20c5d101922" />
<img width="1684" height="959" alt="image" src="https://github.com/user-attachments/assets/869d8369-be35-4f34-ae11-1ed56e31f42b" />
