### PR TITLE
feat(frontend): enhance CreateRecipeForm with ingredient and step management features

### DIFF
--- a/frontend/src/pages/recipe/CreateRecipe.tsx
+++ b/frontend/src/pages/recipe/CreateRecipe.tsx
@@ -11,16 +11,25 @@ import {
 } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+import { recipesService } from "../../services/recipe.service";
+import { ingredientService } from "../../services/ingredient.service";
+import { uploadFiles } from "../../services/upload.service";
+import { showErrorAlert, showSuccessAlert } from "../../utils/errorHandler";
+import CategoryModal from "../../components/modals/Recipe/CategoryModal";
+import type { CreateRecipeDto, IngredientDto, StepDto, ImageDto, UtensilDto, IngredientListItem, FormIngredient, FormStep } from "../../types/recipe.type";
 
 const generateUniqueId = () => `id_${Math.random().toString(36).substr(2, 9)}`;
 
 export default function CreateRecipeForm() {
   const navigate = useNavigate();
+  const { user } = useAuth();
+
   const [recipeName, setRecipeName] = useState("");
   const [description, setDescription] = useState("");
   const [servings, setServings] = useState("1");
   const [cookingTime, setCookingTime] = useState("");
-  const [ingredients, setIngredients] = useState([
+  const [ingredients, setIngredients] = useState<FormIngredient[]>([
     {
       id: generateUniqueId(),
       name: "",
@@ -29,16 +38,242 @@ export default function CreateRecipeForm() {
       ingredientId: null,
     },
   ]);
-  const [ingredientSuggestions, setIngredientSuggestions] = useState([]);
+  const [ingredientSuggestions, setIngredientSuggestions] = useState<IngredientListItem[]>([]);
   const [activeIngredientIndex, setActiveIngredientIndex] = useState(-1);
   const [isSearching, setIsSearching] = useState(false);
-  const [steps, setSteps] = useState([
-    { id: generateUniqueId(), summary: "", detail: "", time: "", images: [] },
+  const [steps, setSteps] = useState<FormStep[]>([
+    { id: generateUniqueId(), summary: "", detail: "", time: "", images: [] as string[] },
   ]);
   const [selectedCategories, setSelectedCategories] = useState([]);
-  const [imagePreview, setImagePreview] = useState(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [visibleCategoryCount] = useState(5);
+  const [categories, setCategories] = useState<{ key: string; name: string; items: { _id: string; name: string }[] }[]>([]);
+  const [showCategoryModal, setShowCategoryModal] = useState(false);
+  const [units, setUnits] = useState<string[]>([]);
+  const [ingredientSearchTimeout, setIngredientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const STANDARD_UNIT_OPTIONS = [
+    "g",
+    "kg",
+    "ml",
+    "l",
+    "cái",
+    "quả",
+    "lá",
+    "nhánh",
+    "thìa",
+    "muỗng",
+  ].map((u) => ({ value: u, label: u }));
+
+  const getDynamicIngredientUnits = (currentIngredient: { unit: string; ingredientId: number | null }) => {
+    const base = [...STANDARD_UNIT_OPTIONS];
+    if (
+      currentIngredient?.unit &&
+      currentIngredient.ingredientId &&
+      !base.some((opt) => opt.value === currentIngredient.unit)
+    ) {
+      return [{ value: currentIngredient.unit, label: currentIngredient.unit }, ...base];
+    }
+    return base;
+  };
+
+  const openCategoryModal = () => setShowCategoryModal(true);
+  const closeCategoryModal = () => setShowCategoryModal(false);
+
+  const getCategoryNameById = (categoryId: string) => {
+    let categoryName = "Danh mục";
+    categories.forEach((group) => {
+      group.items.forEach((cat) => {
+        if (cat._id === categoryId) {
+          categoryName = cat.name;
+        }
+      });
+    });
+    return categoryName;
+  };
+
+  const toggleCategory = (category: { _id: string; name: string }) => {
+    setSelectedCategories((prev: any) =>
+      prev.includes(category._id)
+        ? prev.filter((id: string) => id !== category._id)
+        : [...prev, category._id]
+    );
+  };
+
+  const handleMainImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const result = await uploadFiles([file]);
+      if (result.length > 0) {
+        setImagePreview(result[0].url);
+        setUploadedImages([result[0].url]);
+      }
+    } catch (error) {
+      showErrorAlert(error, "Không thể upload ảnh");
+    }
+  };
+
+  const handleStepImageUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+    stepIndex: number
+  ) => {
+    const files = Array.from(event.target.files || []);
+    if (files.length === 0) return;
+    try {
+      const result = await uploadFiles(files);
+      setSteps((prev) => {
+        const next = [...prev];
+        next[stepIndex] = {
+          ...next[stepIndex],
+          images: [...(next[stepIndex].images as string[]), ...result.map((r) => r.url)],
+        };
+        return next;
+      });
+    } catch (error) {
+      showErrorAlert(error, "Không thể upload ảnh");
+    }
+  };
+
+  const removeStepImage = (stepIndex: number, imageIndex: number) => {
+    setSteps((prev) => {
+      const next = [...prev];
+      next[stepIndex] = {
+        ...next[stepIndex],
+        images: (next[stepIndex].images as string[]).filter((_, i) => i !== imageIndex),
+      };
+      return next;
+    });
+  };
+
+  const searchIngredients = async (query: string, index: number) => {
+    if (!query.trim()) {
+      setIngredientSuggestions([]);
+      setActiveIngredientIndex(-1);
+      return;
+    }
+    try {
+      setIsSearching(true);
+      setActiveIngredientIndex(index);
+      const res = await ingredientService.getIngredients({ keyword: query });
+      setIngredientSuggestions(res.ingredients || []);
+    } catch (error) {
+      setIngredientSuggestions([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleIngredientNameChange = (index: number, value: string) => {
+    setIngredients((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], name: value, ingredientId: null };
+      return next;
+    });
+    if (ingredientSearchTimeout) clearTimeout(ingredientSearchTimeout);
+    const timeoutId = setTimeout(() => searchIngredients(value, index), 200);
+    setIngredientSearchTimeout(timeoutId);
+  };
+
+  const selectIngredient = (index: number, ingredient: IngredientListItem) => {
+    setIngredients((prev) => {
+      const next = [...prev];
+      next[index] = {
+        ...next[index],
+        name: ingredient.name,
+        ingredientId: ingredient.id,
+        unit: ingredient.unit || "",
+      };
+      return next;
+    });
+    setIngredientSuggestions([]);
+    setActiveIngredientIndex(-1);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!user) {
+      showErrorAlert(null, "Vui lòng đăng nhập để tạo công thức");
+      return;
+    }
+    if (!recipeName.trim() || !description.trim()) {
+      showErrorAlert(null, "Vui lòng điền đầy đủ tên và mô tả món ăn");
+      return;
+    }
+    if (ingredients.some((ing) => !ing.name.trim() || !ing.amount.trim())) {
+      showErrorAlert(null, "Vui lòng điền đầy đủ thông tin nguyên liệu");
+      return;
+    }
+    if (steps.some((s) => !s.detail.trim())) {
+      showErrorAlert(null, "Vui lòng điền đầy đủ các bước thực hiện");
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      const validIngredients = ingredients.filter((i) => i.name.trim() && i.amount.trim());
+      const processedIngredients: IngredientDto[] = [];
+      for (const ing of validIngredients) {
+        if (ing.ingredientId) {
+          processedIngredients.push({
+            ingredientId: ing.ingredientId,
+            quantity: parseFloat(ing.amount) || 0,
+            unit: ing.unit || "",
+          });
+        } else {
+          try {
+            const created = await ingredientService.createIngredient({ name: ing.name.trim(), unit: ing.unit || "" });
+            processedIngredients.push({
+              ingredientId: created.ingredient.id,
+              quantity: parseFloat(ing.amount) || 0,
+              unit: ing.unit || "",
+            });
+          } catch (e: any) {
+            const message = (e?.response?.data?.message || e?.message || "").toString().toLowerCase();
+            if (message.includes("already exists") || message.includes("unique") || message.includes("slug")) {
+              try {
+                const search = await ingredientService.getIngredients({ keyword: ing.name.trim(), limit: 10 });
+                const found = (search.ingredients || []).find((it: any) => (it.name || "").toString().toLowerCase() === ing.name.trim().toLowerCase());
+                if (found?.id) {
+                  processedIngredients.push({
+                    ingredientId: found.id,
+                    quantity: parseFloat(ing.amount) || 0,
+                    unit: ing.unit || found.unit || "",
+                  });
+                  continue;
+                }
+              } catch {}
+            }
+            showErrorAlert(e, `Không thể tạo nguyên liệu: ${ing.name}`);
+            return;
+          }
+        }
+      }
+
+      const validSteps = steps.filter((s) => s.detail.trim());
+      const safeDescription = description.trim().slice(0, 180);
+      const recipeData: CreateRecipeDto = {
+        authorId: Number(user.id),
+        title: recipeName.trim(),
+        description: safeDescription,
+        time: parseInt(cookingTime) || 0,
+        ingredients: processedIngredients,
+        steps: validSteps.map((s): StepDto => ({ description: s.detail.trim().slice(0, 180), image: (s.images as string[])[0] })),
+        images: uploadedImages.map((url): ImageDto => ({ imageUrl: url })),
+        utensils: [] as UtensilDto[],
+        categories: { mealType: selectedCategories[0] as any },
+      };
+
+      const resp = await recipesService.createRecipe(recipeData);
+      showSuccessAlert("Tạo công thức thành công!");
+      navigate(`/detail-recipe/${resp.recipe.id}`);
+    } catch (error) {
+      showErrorAlert(error, "Không thể tạo công thức");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="max-w-7xl mx-auto">
@@ -52,7 +287,7 @@ export default function CreateRecipeForm() {
       </div>
 
       <div className="">
-        <form className="space-y-8">
+        <form className="space-y-8" onSubmit={handleSubmit}>
           <div className="grid lg:grid-cols-3 gap-8">
             <div className="lg:col-span-1">
               <label className="block text-base font-medium text-gray-700 mb-3">
@@ -69,6 +304,10 @@ export default function CreateRecipeForm() {
                       />
                       <button
                         type="button"
+                        onClick={() => {
+                          setImagePreview(null);
+                          setUploadedImages([]);
+                        }}
                         className="absolute top-2 right-2 p-2 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors"
                       >
                         <X className="w-4 h-4" />
@@ -76,7 +315,12 @@ export default function CreateRecipeForm() {
                     </div>
                   ) : (
                     <label className="flex flex-col items-center justify-center w-full h-full cursor-pointer">
-                      <input type="file" accept="image/*" className="hidden" />
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={handleMainImageUpload}
+                      />
                       <Upload className="w-12 h-12 text-gray-500 mb-3" />
                       <span className="text-gray-700 font-medium">
                         Tải ảnh lên
@@ -119,6 +363,7 @@ export default function CreateRecipeForm() {
                   key="recipe-description"
                   id="description"
                   value={description}
+                  onChange={(e) => setDescription(e.target.value)}
                   placeholder="Mô tả ngắn gọn về món ăn của bạn..."
                   rows={3}
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 resize-none"
@@ -135,6 +380,7 @@ export default function CreateRecipeForm() {
                     <button
                       type="button"
                       className="px-3 py-4 border border-gray-300 rounded-l-lg bg-gray-100 hover:bg-gray-200 transition-all duration-200"
+                      onClick={() => setServings(Math.max(1, parseInt(servings) - 1).toString())}
                     >
                       <Minus className="w-4 h-4 text-gray-600" />
                     </button>
@@ -149,6 +395,7 @@ export default function CreateRecipeForm() {
                     <button
                       type="button"
                       className="px-3 py-4 border border-gray-300 rounded-r-lg bg-gray-100 hover:bg-gray-200 transition-all duration-200"
+                      onClick={() => setServings((parseInt(servings) + 1).toString())}
                     >
                       <Plus className="w-4 h-4 text-gray-600" />
                     </button>
@@ -180,9 +427,15 @@ export default function CreateRecipeForm() {
                 <div className="flex flex-wrap gap-2 py-1">
                   {selectedCategories
                     .slice(0, visibleCategoryCount)
-                    .map((categoryId, index) => {
+                    .map((categoryId) => {
                       let categoryName = "Unknown";
-
+                      categories.forEach((group) => {
+                        group.items.forEach((cat) => {
+                          if (cat._id === categoryId) {
+                            categoryName = cat.name;
+                          }
+                        });
+                      });
                       return (
                         <button
                           key={categoryId}
@@ -200,14 +453,30 @@ export default function CreateRecipeForm() {
                   )}
                   <button
                     type="button"
+                    onClick={() => setShowCategoryModal(true)}
                     className="px-4 py-2 rounded-full text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 flex items-center justify-center transition-all duration-200"
                   >
                     <Plus className="w-4 h-4" />
                   </button>{" "}
                 </div>{" "}
+                <CategoryModal
+                  isOpen={showCategoryModal}
+                  onClose={() => setShowCategoryModal(false)}
+                  categories={categories as any}
+                  selectedCategories={selectedCategories as any}
+                  onToggleCategory={(cat: any) => {
+                    setSelectedCategories((prev: any) => (
+                      prev.includes(cat._id)
+                        ? prev.filter((id: string) => id !== cat._id)
+                        : [...prev, cat._id]
+                    ));
+                  }}
+                  onClearAll={() => setSelectedCategories([] as any)}
+                />
               </div>
             </div>
           </div>{" "}
+
           <div className="grid lg:grid-cols-2 gap-8">
             <div className="bg-gray-50 rounded-xl border border-gray-200">
               <div className="p-6">
@@ -221,7 +490,7 @@ export default function CreateRecipeForm() {
                 <div className="space-y-3">
                   {ingredients.map((ingredient, idx) => (
                     <div
-                      key={`ingredient-${idx}-${ingredient.name}`}
+                      key={ingredient.id}
                       className="flex items-center gap-3 bg-white p-3 rounded-lg shadow-sm border border-gray-100"
                     >
                       {" "}
@@ -231,6 +500,9 @@ export default function CreateRecipeForm() {
                             type="text"
                             placeholder="Tên nguyên liệu"
                             value={ingredient.name}
+                            onChange={(e) =>
+                              handleIngredientNameChange(idx, e.target.value)
+                            }
                             className={`w-full p-3 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
                               ingredient.ingredientId
                                 ? "border-green-500 bg-green-50"
@@ -263,11 +535,20 @@ export default function CreateRecipeForm() {
                               <div className="absolute z-10 w-full mt-1 bg-white shadow-lg rounded-md border border-gray-200 max-h-48 overflow-y-auto">
                                 {ingredientSuggestions.map((suggestion) => (
                                   <button
+                                    key={suggestion.id}
                                     type="button"
+                                    onClick={() =>
+                                      selectIngredient(idx, suggestion)
+                                    }
                                     className="w-full text-left px-3 py-2 hover:bg-gray-100 transition-colors"
                                   >
                                     <div className="flex justify-between">
-                                      <span>Name</span>
+                                      <span>{suggestion.name}</span>
+                                      {suggestion.unit && (
+                                        <span className="text-gray-500 text-sm">
+                                          {suggestion.unit}
+                                        </span>
+                                      )}
                                     </div>
                                   </button>
                                 ))}
@@ -304,6 +585,16 @@ export default function CreateRecipeForm() {
                           type="text"
                           placeholder="Số lượng"
                           value={ingredient.amount}
+                          onChange={(e) => {
+                            setIngredients((prevIngredients) => {
+                              const newIngredients = [...prevIngredients];
+                              newIngredients[idx] = {
+                                ...newIngredients[idx],
+                                amount: e.target.value,
+                              };
+                              return newIngredients;
+                            });
+                          }}
                           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                           required
                         />
@@ -311,19 +602,28 @@ export default function CreateRecipeForm() {
                       <div className="w-24">
                         <select
                           value={ingredient.unit}
+                          onChange={(e) => {
+                            setIngredients((prevIngredients) => {
+                              const newIngredients = [...prevIngredients];
+                              newIngredients[idx] = {
+                                ...newIngredients[idx],
+                                unit: e.target.value,
+                              };
+                              return newIngredients;
+                            });
+                          }}
                           disabled={!!ingredient.ingredientId}
                           className={`w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500 focus:border-transparent ${
                             ingredient.ingredientId
                               ? "border-green-500 bg-green-50 text-gray-600 cursor-not-allowed"
                               : "border-gray-300"
                           }`}
-                          title={
-                            ingredient.ingredientId
-                              ? "Đơn vị được khóa cho nguyên liệu từ database"
-                              : ""
-                          }
+                          title={ingredient.ingredientId ? "Đơn vị được khóa cho nguyên liệu từ database" : ""}
                         >
                           <option value="">Đơn vị</option>
+                          {getDynamicIngredientUnits(ingredient).map((opt) => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
                         </select>
                       </div>
                       {ingredients.length > 1 && (
@@ -332,6 +632,7 @@ export default function CreateRecipeForm() {
                           variant="outline"
                           size="sm"
                           className="text-red-500 border-red-200 hover:bg-red-50"
+                          onClick={() => setIngredients((prev) => prev.filter((_, i) => i !== idx))}
                         >
                           <Minus className="w-4 h-4" />
                         </Button>
@@ -342,6 +643,7 @@ export default function CreateRecipeForm() {
                     type="button"
                     variant="outline"
                     className="w-full border-dashed border-gray-300 text-gray-600 hover:bg-gray-100"
+                    onClick={() => setIngredients((prev) => ([...prev, { id: generateUniqueId(), name: "", amount: "", unit: "", ingredientId: null }]))}
                   >
                     <Plus className="w-4 h-4 mr-2" />
                     Thêm nguyên liệu
@@ -362,7 +664,7 @@ export default function CreateRecipeForm() {
                   {" "}
                   {steps.map((step, idx) => (
                     <div
-                      key={`step-${idx}-${step.summary}`}
+                      key={step.id}
                       className="bg-white p-4 rounded-lg shadow-sm border-l-4 border-yellow-400"
                     >
                       {" "}
@@ -376,18 +678,48 @@ export default function CreateRecipeForm() {
                               type="text"
                               placeholder="Tiêu đề bước (tuỳ chọn)"
                               value={step.summary}
+                              onChange={(e) => {
+                                setSteps((prevSteps) => {
+                                  const newSteps = [...prevSteps];
+                                  newSteps[idx] = {
+                                    ...newSteps[idx],
+                                    summary: e.target.value,
+                                  };
+                                  return newSteps;
+                                });
+                              }}
                               className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-yellow-500 focus:border-transparent font-medium text-sm"
                             />
                             <input
                               type="text"
                               placeholder="Thời gian"
                               value={step.time}
+                              onChange={(e) => {
+                                setSteps((prevSteps) => {
+                                  const newSteps = [...prevSteps];
+                                  newSteps[idx] = {
+                                    ...newSteps[idx],
+                                    time: e.target.value,
+                                  };
+                                  return newSteps;
+                                });
+                              }}
                               className="w-20 px-2 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-yellow-500 focus:border-transparent text-center text-sm"
                             />
                           </div>
                           <textarea
                             placeholder="Mô tả chi tiết cách thực hiện..."
                             value={step.detail}
+                            onChange={(e) => {
+                              setSteps((prevSteps) => {
+                                const newSteps = [...prevSteps];
+                                newSteps[idx] = {
+                                  ...newSteps[idx],
+                                  detail: e.target.value,
+                                };
+                                return newSteps;
+                              });
+                            }}
                             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-yellow-500 focus:border-transparent resize-none text-sm"
                             rows={2}
                             required
@@ -402,6 +734,7 @@ export default function CreateRecipeForm() {
                                     className="relative w-20 h-20"
                                   >
                                     <img
+                                      src={image}
                                       alt={`Step ${idx + 1} image ${
                                         imageIdx + 1
                                       }`}
@@ -409,6 +742,9 @@ export default function CreateRecipeForm() {
                                     />
                                     <button
                                       type="button"
+                                      onClick={() =>
+                                        removeStepImage(idx, imageIdx)
+                                      }
                                       className="absolute -top-1 -right-1 p-1 bg-red-500 text-white rounded-full shadow-sm hover:bg-red-600 transition-colors"
                                     >
                                       <X className="w-3 h-3" />
@@ -423,6 +759,9 @@ export default function CreateRecipeForm() {
                                     multiple
                                     accept="image/*"
                                     className="hidden"
+                                    onChange={(e) =>
+                                      handleStepImageUpload(e, idx)
+                                    }
                                   />
                                   <ImageIcon className="w-6 h-6 text-gray-400" />
                                   <span className="text-xs text-gray-500 mt-1">
@@ -439,6 +778,7 @@ export default function CreateRecipeForm() {
                             variant="outline"
                             size="sm"
                             className="text-red-500 border-red-200 hover:bg-red-50 flex-shrink-0"
+                            onClick={() => setSteps((prev) => prev.filter((_, i) => i !== idx))}
                           >
                             <X className="w-3 h-3" />
                           </Button>
@@ -449,6 +789,7 @@ export default function CreateRecipeForm() {
                   <Button
                     type="button"
                     variant="outline"
+                    onClick={() => setSteps((prev) => ([...prev, { id: generateUniqueId(), summary: "", detail: "", time: "", images: [] }]))}
                     className="w-full border-dashed border-gray-300 text-gray-600 hover:bg-gray-100"
                   >
                     <Plus className="w-4 h-4 mr-2" />

--- a/frontend/src/services/recipe.service.ts
+++ b/frontend/src/services/recipe.service.ts
@@ -44,7 +44,7 @@ export const recipesService = {
 
   async createRecipe(createRecipeDto: CreateRecipeDto) {
     try {
-      const response = await post("/recipes", createRecipeDto);
+      const response = await post("/recipes", { recipe: createRecipeDto });
       return response.data;
     } catch (error) {
       throw error;
@@ -53,7 +53,7 @@ export const recipesService = {
 
   async updateRecipe(id: number, updateRecipeDto: UpdateRecipeDto) {
     try {
-      const response = await put(`/recipes/${id}`, updateRecipeDto);
+      const response = await put(`/recipes/${id}`, { recipe: updateRecipeDto });
       return response.data;
     } catch (error) {
       throw error;

--- a/frontend/src/types/recipe.type.ts
+++ b/frontend/src/types/recipe.type.ts
@@ -111,3 +111,25 @@ export interface RecipeListItem {
   createdAt?: string;
   updatedAt?: string;
 }
+
+export type IngredientListItem = {
+  id: number;
+  name: string;
+  unit?: string;
+};
+
+export type FormIngredient = {
+  id: string;
+  name: string;
+  amount: string;
+  unit: string;
+  ingredientId: number | null;
+};
+
+export type FormStep = {
+  id: string;
+  summary: string;
+  detail: string;
+  time: string;
+  images: string[];
+};


### PR DESCRIPTION
# Related Tickets

[Ticket redmine link](https://edu-redmine.sun-asterisk.vn/issues/90842)

# Feature: Create Recipe: integrate backend, improve ingredient UX, and fix navigation

This PR connects the Create Recipe page to the backend, improves the ingredient UX (search, unit handling, and new ingredient creation).

### Create Recipe

1. API integration: upload main/step images, create new ingredients if not found, send data via recipesService (payload wrapped in { recipe: … } to match backend controller).

2. Ingredient UX:

- Autocomplete search with debounce.
- Dynamic unit list: default units + DB unit of the chosen ingredient; lock unit select when ingredient is chosen from DB.
- Stable list keys and immutable state updates for smooth typing.

3. Validation: front-end checks for required fields, at least one ingredient and one step, and safe numeric conversions.

4. Type safety: remove as any[], add proper DTO types (IngredientDto, StepDto, ImageDto, UtensilDto).
Redirect on success to /detail-recipe/:id using response.recipe.id.
Services

### UI Preview
<img width="1705" height="656" alt="image" src="https://github.com/user-attachments/assets/e0e1b8e7-75b8-484d-92ff-827b56086f68" />
<img width="1559" height="793" alt="image" src="https://github.com/user-attachments/assets/12e82c67-fe7d-4ecd-8901-2beef1e879a4" />

