### PR TITLE
fix: Redirect loop on login

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -60,6 +60,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         loading,
         login,
         logout,
+        checkAuth
       }}
     >
       {children}

--- a/frontend/src/pages/auth/Login/Login.tsx
+++ b/frontend/src/pages/auth/Login/Login.tsx
@@ -4,7 +4,7 @@ import bgImage from "../../../assets/login/background.png";
 import bowl from "../../../assets/login/bowl.png";
 import logo from "../../../assets/logo.svg";
 import type { LoginDto, LoginErrors } from "../../../types/auth.type";
-import { login } from "../../../services/auth.service";
+import { useAuth } from "../../../contexts/AuthContext";
 
 const Login = () => {
   const [formData, setFormData] = useState<LoginDto>({
@@ -21,6 +21,7 @@ const Login = () => {
   const passwordRef = useRef<HTMLInputElement>(null);
 
   const navigate = useNavigate();
+  const { login: authLogin, checkAuth } = useAuth();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -81,7 +82,8 @@ const Login = () => {
     }
 
     try {
-      await login(formData);
+      await authLogin(formData);
+      await checkAuth();
       navigate("/");
     } catch (error: any) {
       setApiError(error?.message || "Đăng nhập thất bại. Vui lòng thử lại.");

--- a/frontend/src/types/auth.type.ts
+++ b/frontend/src/types/auth.type.ts
@@ -44,5 +44,6 @@ export interface AuthContextProps {
   user: User | null;
   loading: boolean;
   login: (loginDto: LoginDto) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
+  checkAuth: () => Promise<void>;
 }


### PR DESCRIPTION
## Redmine ticket:
Ticket Link

## Description:
This PR addresses a bug where users would get stuck in an infinite redirect loop after successfully logging in. The issue occurred because the `Feed` component would attempt to redirect to the login page before the `AuthContext` had finished updating the user's state.

## Changes
- **Updated `AuthContext`:** Added `checkAuth` function as AuthContextProps to manually check the user state.
- **Updated `Login` component:** After a successful login, the `checkAuth` function is now called to ensure the user state is updated immediately before navigating to the home page. This prevents the `Feed` component from mistakenly redirecting the user back to `/login`.

## Why This Fix Works
By explicitly refreshing the user state in the `Login` component, we ensure that the `Feed` component has the most up-to-date `user` data when it renders. This breaks the redirect loop and allows the user to access the main feed as expected.