### PR TITLE
fix: update message content display to use break-all for better text wrapping

### DIFF
--- a/frontend/src/pages/main/Message/MessagePage.tsx
+++ b/frontend/src/pages/main/Message/MessagePage.tsx
@@ -1290,7 +1290,7 @@ export default function MessagePage() {
                                                   .senderUser.lastName
                                               }
                                             </div>
-                                            <div className="truncate">
+                                            <div className="truncate break-all">
                                               {(() => {
                                                 const rt =
                                                   message.replyToMessage?.type;
@@ -1342,7 +1342,7 @@ export default function MessagePage() {
                                         {(() => {
                                           if (message.type === "TEXT") {
                                             return (
-                                              <p className="text-sm">
+                                              <p className="text-sm break-all">
                                                 {message.content}
                                               </p>
                                             );
@@ -1388,7 +1388,7 @@ export default function MessagePage() {
                                               );
                                             } catch {
                                               return (
-                                                <p className="text-sm break-words">
+                                                <p className="text-sm break-all">
                                                   {message.content}
                                                 </p>
                                               );
@@ -1435,7 +1435,7 @@ export default function MessagePage() {
                                               );
                                             } catch {
                                               return (
-                                                <p className="text-sm">
+                                                <p className="text-sm break-all">
                                                   {message.content}
                                                 </p>
                                               );
@@ -1479,14 +1479,14 @@ export default function MessagePage() {
                                               );
                                             } catch {
                                               return (
-                                                <p className="text-sm">
+                                                <p className="text-sm break-words">
                                                   {message.content}
                                                 </p>
                                               );
                                             }
                                           }
                                           return (
-                                            <p className="text-sm">
+                                            <p className="text-sm break-all">
                                               {message.content}
                                             </p>
                                           );


### PR DESCRIPTION
### Related Tickets

[Ticket redmine link](https://edu-redmine.sun-asterisk.vn/issues/92522)


# Feature 1:

- Fix the display issue with long messages that have no spaces.
<img width="1910" height="868" alt="image" src="https://github.com/user-attachments/assets/0944b445-bf16-480a-905f-c392129041d4" />
